### PR TITLE
Event view 

### DIFF
--- a/src/app/event-view/components/tree/event-tree.component.ts
+++ b/src/app/event-view/components/tree/event-tree.component.ts
@@ -82,30 +82,28 @@ export class EventTreeComponent {
     return ret;
   }
 
-    ngOnChanges() {
-      if (this.dbIdAndClassNameFromPlotToEventTree) {
-          let selectedParams: string = this.dbIdAndClassNameFromPlotToEventTree.split(",")[0];
-          let parentParams: string = this.dbIdAndClassNameFromPlotToEventTree.split(",")[1];
-          let selectedDbId = parseInt(selectedParams.split(":")[0]);
-          let parentDbId = parseInt(parentParams.split(":")[0]);
-          // Highlight in the event tree the node corresponding to the event selected by the user within the plot
-          // (and remove highlighting from all the other nodes); also - expand the parent node of the selected one -
-          // in order to bring the selected one into view.
-          this.treeControl.dataNodes.forEach( (node) => {
-            if (node.dbId === selectedDbId) {
-              node.match = true;
-            } else if (node.dbId === parentDbId) {
-              this.treeControl.expand(node);
-              node.match = false;
-            } else {
-              node.match = false;
-            }
-          });
-          const element = document.querySelector('.match') as HTMLElement;
-          element.scrollIntoView({behavior: 'smooth'});
-          this.cdr.detectChanges();
-      }
+  ngOnChanges() {
+    if (this.dbIdAndClassNameFromPlotToEventTree) {
+        let selectedParams: string = this.dbIdAndClassNameFromPlotToEventTree.split(",")[0];
+        let parentParams: string = this.dbIdAndClassNameFromPlotToEventTree.split(",")[1];
+        let selectedDbId = parseInt(selectedParams.split(":")[0]);
+        let parentDbId = parseInt(parentParams.split(":")[0]);
+        // Highlight in the event tree the node corresponding to the event selected by the user within the plot
+        // (and remove highlighting from all the other nodes); also - expand the parent node of the selected one -
+        // in order to bring the selected one into view.
+        this.treeControl.dataNodes.forEach( (node) => {
+          if (node.dbId === selectedDbId) {
+            node.match = true;
+          } else if (node.dbId === parentDbId) {
+            this.treeControl.expand(node);
+            node.match = false;
+          } else {
+            node.match = false;
+          }
+        });
+        this.cdr.detectChanges();
     }
+  }
 
 
   // Emit an event to the parent: side-navigation.component

--- a/src/app/event-view/graphic-display/components/event-plot/event-plot.component.ts
+++ b/src/app/event-view/graphic-display/components/event-plot/event-plot.component.ts
@@ -241,7 +241,6 @@ export class EventPlotComponent {
       graph.on('node:click', evt => {
         const node = evt.item;
         const plotParams = node!._cfg!.model!['plotParams'] as string;
-        this.generatePlot(plotParams);
         // Passing the event with the selected plot dbId:ClassName (plotParams)
         // as well as the original one (dbIdAndClassName) - so that event tree node
         // corresponding to the original one can be expanded - in order to show

--- a/src/app/event-view/main-event/main-event.component.ts
+++ b/src/app/event-view/main-event/main-event.component.ts
@@ -75,5 +75,12 @@ export class MainEventComponent {
 
   updateEventTreeToSideNavigation(dbIdAndClassNameFromPlot: string) {
     this.dbIdAndClassNameFromPlot = dbIdAndClassNameFromPlot;
+    // Note that the below has an effect of the new plot being generated (as this.dbIdAndClassName is an input to
+    // event-plot.component), but we trigger plot generation from here rather than within event-plot.component
+    // so that we can override this.dbIdAndClassName with the new event selection in the plot (if we hadn't, the next time
+    // the user selects in the event tree the previously selected event, ngOnChanges() in event-plot.component won't kick in
+    // and no plot will be generated).
+    let selectedDbIdAndClassName = dbIdAndClassNameFromPlot.split(",")[0];
+    this.dbIdAndClassName = selectedDbIdAndClassName;
   }
 }


### PR DESCRIPTION
Fixed a bug where if the user generated a plot from event tree, then clicked on a node within a plot to generate a new plot, and then went back to the event tree and clicked again on the original event - and no plot for the original event was generated.