### PR TITLE
shrink mat-sidenav-container on open bookmark

### DIFF
--- a/src/app/schema-view/main-schema-view/main-schema-view.component.html
+++ b/src/app/schema-view/main-schema-view/main-schema-view.component.html
@@ -1,5 +1,6 @@
 <div #container>
   <mat-sidenav-container (dragover)="$event.preventDefault()" autosize="true"
+    [class.bookmark-open]="status.opened"
     style="height: 94vh; overflow: visible !important">
     <mat-sidenav #sidenav mode="side" opened (openedChange)="schemaPanelOpen" [disableClose]="true"
       [style.width]="sideWidth + 'px'">

--- a/src/app/schema-view/main-schema-view/main-schema-view.component.scss
+++ b/src/app/schema-view/main-schema-view/main-schema-view.component.scss
@@ -1,3 +1,21 @@
+:host {
+  --bookmark-width: 250px;
+  --border-width: 2px;
+  --handle-width: 20px;
+}
+
+// When the bookmark panel slides out it is fixed over the right edge of the
+// viewport, on top of the content's vertical scrollbar. Shrink the sidenav
+// container by the panel + handle width so the scrollbar shifts left and stays
+// reachable. Transition matches the panel's 500ms slide.
+mat-sidenav-container {
+  transition: width 500ms ease;
+
+  &.bookmark-open {
+    width: calc(100% - var(--bookmark-width) - var(--handle-width));
+  }
+}
+
 .resize-container {
   position: absolute;
   top: 0;
@@ -59,10 +77,6 @@ side-nav {
 
 
 #bookmark-boundary {
-  --bookmark-width: 250px;
-  --border-width: 2px;
-  --handle-width: 20px;
-
   position: fixed;
   pointer-events: none;
   right: calc(-1 *  var(--bookmark-width) - var(--border-width));


### PR DESCRIPTION
  The bookmark panel (#bookmark-boundary) is position: fixed against the right edge of the viewport. When it
  slides open, it lands directly on top of the content area's vertical scrollbar — the scrollbar belongs to
  mat-sidenav-content, which fills all the way to the right edge — so you can't grab it.

  The fix

  When the panel is open, I shrink the mat-sidenav-container so the content (and its right-edge scrollbar)
  shifts left, out from under both the panel and its handle.